### PR TITLE
Add wine flashing hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ At present we have the following achievements using the FlySky i6:
 - There is a guide to FTDI flashing i6 with different official firmware: (http://dalybulge.blogspot.co.uk/2015/10/turnigyflysky-i6-secret-menu.html?view=classic)
 - There is a guide to flashing i6 for 8ch mod using Jtag(https://github.com/ThomHPL/FSi6_updater) Also guide (https://basejunction.wordpress.com/2015/09/13/en-flysky-i6-part-3-firmware-patching/)
 - Experiments using Arduino IDE v1.6.6 are ongoing (https://www.arduino.cc/en/Main/Software), with Teensyduino Add-on (https://www.pjrc.com/teensy/teensyduino.html) (Settings > Board > Teensy LC > 48mhz) (LCD example: ST7565)
+- Flashing under Linux (wine) is possible, but you may need to map wine's COM1 to the actual com port (e.g. /dev/ttyUSB0)
+(https://www.winehq.org/docs/wineusr-guide/misc-things-to-configure#AEN901)
 
 More will be added/edited as progress is made. Please send me PM me if you have changes/updates: 
 email:i6mods@gmail.com


### PR DESCRIPTION
I managed to flash under wine by creating a symlink between COM1 and /dev/ttyUSB0 - couldn't find this documented anywhere